### PR TITLE
Add cloudfront test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,119 @@
+# Test Suite
+
+This directory contains integration tests for the spacelift-intent library.
+
+## Prerequisites
+
+### AWS Credentials
+
+For AWS provider tests (like CloudFront), create a `.env.aws` file in the project root with your AWS credentials:
+
+```bash
+AWS_ACCESS_KEY_ID="your_access_key_id"
+AWS_SECRET_ACCESS_KEY="your_secret_access_key"
+AWS_REGION="us-east-1"
+```
+
+The test will automatically load and set these environment variables. Values can be quoted or unquoted.
+
+## Running Tests
+
+### All Integration Tests
+
+```bash
+go test ./test -v
+```
+
+### CloudFront Distribution Tests
+
+CloudFront distributions take several minutes to create/delete, so use extended timeouts:
+
+```bash
+GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn USE_OPENTOFU_PROVIDER_LIB=true go test -timeout 1000s -run ^TestCloudFrontDistributionCreate github.com/spacelift-io/spacelift-intent/test -v
+```
+
+### Environment Variables
+
+- `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn` - Suppresses protobuf registration warnings
+- `USE_OPENTOFU_PROVIDER_LIB=true` - Enables OpenTofu provider library mode
+- `-timeout 1000s` - Sets test timeout to ~17 minutes (CloudFront operations can take 5-15 minutes)
+
+### Test Structure
+
+The CloudFront test (`TestCloudFrontDistributionCreate`) performs a complete lifecycle:
+
+1. **Create** - Creates a CloudFront distribution with custom origin configuration
+2. **Refresh** - Refreshes the resource state from AWS
+3. **Get State** - Retrieves the current resource state
+4. **Delete** - Cleans up the CloudFront distribution
+
+Each operation is tested separately and logs detailed output for debugging.
+
+## Test Configuration
+
+The CloudFront test uses this configuration:
+
+```json
+{
+  "origin": [
+    {
+      "domain_name": "example.com",
+      "origin_id": "example",
+      "custom_origin_config": [
+        {
+          "http_port": 80,
+          "https_port": 443,
+          "origin_protocol_policy": "https-only",
+          "origin_ssl_protocols": ["TLSv1.2"]
+        }
+      ]
+    }
+  ],
+  "enabled": true,
+  "default_cache_behavior": [
+    {
+      "target_origin_id": "example",
+      "allowed_methods": ["GET", "HEAD"],
+      "cached_methods": ["GET", "HEAD"],
+      "cache_policy_id": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+      "viewer_protocol_policy": "redirect-to-https"
+    }
+  ],
+  "restrictions": [
+    {
+      "geo_restriction": [
+        {
+          "restriction_type": "none"
+        }
+      ]
+    }
+  ],
+  "viewer_certificate": [
+    {
+      "cloudfront_default_certificate": true
+    }
+  ],
+  "comment": "Example CloudFront distribution",
+  "tags": {
+    "Environment": "production",
+    "Name": "example-distribution"
+  }
+}
+```
+
+## Troubleshooting
+
+### Timeout Issues
+- CloudFront distributions can take 5-15 minutes to deploy
+- Use `-timeout 1000s` or higher for CloudFront tests
+- The test helper uses a 10-minute context timeout internally
+
+### Credential Issues
+- Ensure `.env.aws` file exists in project root
+- Verify AWS credentials have CloudFront permissions
+- Check AWS region is set correctly
+
+### Provider Issues
+- Set `USE_OPENTOFU_PROVIDER_LIB=true` environment variable
+- Use `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn` to suppress warnings
+- Ensure AWS provider is available in the test environment

--- a/test/cloudfront_test.go
+++ b/test/cloudfront_test.go
@@ -1,0 +1,239 @@
+package test
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcptest"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacelift-io/spacelift-intent/provider"
+	"github.com/spacelift-io/spacelift-intent/registry"
+	"github.com/spacelift-io/spacelift-intent/storage"
+	"github.com/spacelift-io/spacelift-intent/tools"
+)
+
+// loadAWSCredentials loads AWS credentials from .env.aws file
+func loadAWSCredentials(t *testing.T) map[string]string {
+	file, err := os.Open(".env.aws")
+	if err != nil {
+		t.Skip("Skipping test: .env.aws file not found")
+		return nil
+	}
+	defer file.Close()
+
+	credentials := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+
+			// Remove surrounding quotes if present
+			if len(value) >= 2 && ((value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'')) {
+				value = value[1 : len(value)-1]
+			}
+
+			credentials[key] = value
+		}
+	}
+
+	require.NoError(t, scanner.Err(), "Failed to read .env.aws file")
+
+	// Verify required AWS credentials are present
+	requiredKeys := []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"}
+	for _, key := range requiredKeys {
+		require.NotEmpty(t, credentials[key], "Missing required AWS credential: %s", key)
+	}
+
+	return credentials
+}
+
+// NewTestHelperWithTimeout creates a test helper with custom timeout for long-running operations
+func NewTestHelperWithTimeout(t *testing.T, timeout time.Duration) *TestHelper {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	// Create temporary directories
+	tempDir := t.TempDir()
+	dbDir := filepath.Join(tempDir, "db")
+	err := os.MkdirAll(dbDir, 0755)
+	require.NoError(t, err, "Failed to create database directory")
+
+	// Initialize storage
+	stor, err := storage.NewSQLiteStorage(filepath.Join(dbDir, "state.db"))
+	require.NoError(t, err, "Failed to initialize storage")
+
+	// Initialize registry client
+	registryClient := registry.NewOpenTofuClient()
+
+	// Initialize provider manager
+	providerManager := provider.NewAdaptiveManager(tempDir, registryClient)
+
+	// Create tool handlers
+	toolHandlers := tools.New(registryClient, providerManager, stor)
+
+	// Convert tools to server tools
+	mcpTools := toolHandlers.Tools()
+	serverTools := make([]server.ServerTool, 0, len(mcpTools))
+	for _, tool := range mcpTools {
+		serverTools = append(serverTools, server.ServerTool{
+			Tool:    tool.Tool,
+			Handler: tool.Handler,
+		})
+	}
+
+	// Create test server
+	testServer := mcptest.NewUnstartedServer(t)
+	testServer.AddTools(serverTools...)
+
+	// Start the server
+	err = testServer.Start(ctx)
+	require.NoError(t, err, "Failed to start test server")
+
+	return &TestHelper{
+		t:       t,
+		ctx:     ctx,
+		cancel:  cancel,
+		tempDir: tempDir,
+		dbDir:   dbDir,
+		server:  testServer,
+		client:  testServer.Client(),
+	}
+}
+
+// TestCloudFrontDistributionCreate tests creating a CloudFront distribution using lifecycle-resources-create
+func TestCloudFrontDistributionCreate(t *testing.T) {
+	// Load AWS credentials from .env.aws
+	credentials := loadAWSCredentials(t)
+	if credentials == nil {
+		return // Test was skipped
+	}
+
+	// Set environment variables for the test
+	for key, value := range credentials {
+		t.Setenv(key, value)
+	}
+
+	// Use extended timeout for CloudFront operations (10 minutes)
+	th := NewTestHelperWithTimeout(t, 10*time.Minute)
+	defer th.Cleanup()
+
+	const resourceID = "test-cloudfront-distribution"
+	const provider = "hashicorp/aws"
+	const resourceType = "aws_cloudfront_distribution"
+
+	// CloudFront distribution configuration
+	cloudFrontConfig := map[string]any{
+		"origin": []map[string]any{
+			{
+				"domain_name": "example.com",
+				"origin_id":   "example",
+				"custom_origin_config": []map[string]any{
+					{
+						"http_port":              80,
+						"https_port":             443,
+						"origin_protocol_policy": "https-only",
+						"origin_ssl_protocols":   []string{"TLSv1.2"},
+					},
+				},
+			},
+		},
+		"enabled": true,
+		"default_cache_behavior": []map[string]any{
+			{
+				"target_origin_id":       "example",
+				"allowed_methods":        []string{"GET", "HEAD"},
+				"cached_methods":         []string{"GET", "HEAD"},
+				"cache_policy_id":        "658327ea-f89d-4fab-a63d-7e88639e58f6",
+				"viewer_protocol_policy": "redirect-to-https",
+			},
+		},
+		"restrictions": []map[string]any{
+			{
+				"geo_restriction": []map[string]any{
+					{
+						"restriction_type": "none",
+					},
+				},
+			},
+		},
+		"viewer_certificate": []map[string]any{
+			{
+				"cloudfront_default_certificate": true,
+			},
+		},
+		"comment": "Example CloudFront distribution",
+		"tags": map[string]string{
+			"Environment": "production",
+			"Name":        "example-distribution",
+		},
+	}
+
+	t.Run("CreateCloudFrontDistribution", func(t *testing.T) {
+		result, err := th.CallTool("lifecycle-resources-create", map[string]any{
+			"resource_id":   resourceID,
+			"provider":      provider,
+			"resource_type": resourceType,
+			"config":        cloudFrontConfig,
+		})
+		th.AssertToolSuccess(result, err, "lifecycle-resources-create")
+
+		content := th.GetTextContent(result)
+		require.Contains(t, content, resourceID, "Create result should contain resource ID")
+		require.Contains(t, content, "created", "Should show created status")
+
+		t.Logf("CloudFront distribution created successfully: %s", content)
+	})
+
+	t.Run("RefreshCloudFrontDistribution", func(t *testing.T) {
+		result, err := th.CallTool("lifecycle-resources-refresh", map[string]any{
+			"resource_id": resourceID,
+		})
+		th.AssertToolSuccess(result, err, "lifecycle-resources-refresh")
+
+		content := th.GetTextContent(result)
+		require.Contains(t, content, resourceID, "Refresh result should contain resource ID")
+
+		t.Logf("CloudFront distribution refreshed: %s", content)
+	})
+
+	t.Run("GetCloudFrontDistributionState", func(t *testing.T) {
+		result, err := th.CallTool("state-get", map[string]any{
+			"resource_id": resourceID,
+		})
+		th.AssertToolSuccess(result, err, "state-get")
+
+		content := th.GetTextContent(result)
+		require.Contains(t, content, resourceID, "State should contain resource ID")
+		require.Contains(t, content, "aws_cloudfront_distribution", "State should contain resource type")
+
+		t.Logf("CloudFront distribution state: %s", content)
+	})
+
+	t.Run("DeleteCloudFrontDistribution", func(t *testing.T) {
+		result, err := th.CallTool("lifecycle-resources-delete", map[string]any{
+			"resource_id": resourceID,
+		})
+		th.AssertToolSuccess(result, err, "lifecycle-resources-delete")
+
+		content := th.GetTextContent(result)
+		require.Contains(t, content, resourceID, "Delete result should contain resource ID")
+		require.Contains(t, content, "deleted", "Should show deleted status")
+
+		t.Logf("CloudFront distribution deleted: %s", content)
+	})
+}


### PR DESCRIPTION
**Summary**
- Add CloudFront distribution integration test using lifecycle-resources-create tool
- Implement .env.aws credential loading with proper quote handling
- Create extended timeout test helper for long-running AWS operations
- Add comprehensive test documentation with run commands

**Test plan**
- Test loads AWS credentials from .env.aws file
- Test handles quoted credential values correctly
- Test creates CloudFront distribution with provided config
- Test performs full lifecycle (create, refresh, get state, delete)
- Test uses 10-minute timeout for CloudFront operations
- Documentation includes proper run commands with environment variables

Running it with new adapter:
<img width="874" height="605" alt="image" src="https://github.com/user-attachments/assets/92b8bfe9-e208-4b84-9c51-dc5e874629f7" />

Running with old:
<img width="891" height="321" alt="image" src="https://github.com/user-attachments/assets/14a25da1-b3a6-4c11-a710-7ff21226bf00" />

