### PR TITLE
docs: fix brew url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configure your MCP host to use the Docker container. See the [Configuration](#co
 Install via Homebrew:
 
 ```bash
-brew install spacelift-io/tap/spacelift-intent
+brew install spacelift-io/spacelift/spacelift-intent
 ```
 
 ### Manual Installation


### PR DESCRIPTION
## Summary

This PR corrects the Homebrew installation path in the README from `spacelift-io/tap/spacelift-intent` to `spacelift-io/spacelift/spacelift-intent`.

## Changes

- Updated the Homebrew tap URL to use the correct repository path

## Reason

The previous URL was using an incorrect tap name (`tap`) instead of the actual repository name (`spacelift`), which would cause the installation command to fail for users trying to install via Homebrew.

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Changes follow project conventions
- [x] Documentation has been updated
- [x] Changes are backward compatible