### PR TITLE
fix: return partial state from provider on failed create

### DIFF
--- a/provider/opentofu_adapter.go
+++ b/provider/opentofu_adapter.go
@@ -483,22 +483,37 @@ func (a *OpenTofuAdapter) CreateResource(ctx context.Context, providerConfig *ty
 		return nil, fmt.Errorf("apply failed: %w", err)
 	}
 
+	var applyErr error
 	if applyResp.Diagnostics().HasErrors() {
-		return nil, fmt.Errorf("apply failed: %s", a.formatDiagnostics(applyResp.Diagnostics()))
+		applyErr = fmt.Errorf("apply failed: %s", a.formatDiagnostics(applyResp.Diagnostics()))
 	}
 
-	// Convert final state back to map
-	finalStateCty, err := applyResp.PlannedNewState().AsCtyValue(resourceTypeCty)
+	// Convert final state back to map — PlannedNewState() can be nil when diagnostics have errors.
+	newState := applyResp.PlannedNewState()
+	if newState == nil {
+		if applyErr != nil {
+			return nil, applyErr
+		}
+		return nil, errors.New("apply returned nil state")
+	}
+
+	finalStateCty, err := newState.AsCtyValue(resourceTypeCty)
 	if err != nil {
+		if applyErr != nil {
+			return nil, applyErr
+		}
 		return nil, fmt.Errorf("failed to decode final state: %w", err)
 	}
 
 	finalStateMap, err := a.converter.CtyValueToMap(finalStateCty)
 	if err != nil {
+		if applyErr != nil {
+			return nil, applyErr
+		}
 		return nil, fmt.Errorf("failed to convert final state to map: %w", err)
 	}
 
-	return finalStateMap, nil
+	return finalStateMap, applyErr
 }
 
 func (a *OpenTofuAdapter) DeleteResource(ctx context.Context, providerConfig *types.ProviderConfig, resourceType string, state map[string]any) error {

--- a/tools/lifecycle/resources/create.go
+++ b/tools/lifecycle/resources/create.go
@@ -110,13 +110,12 @@ func create(storage types.Storage, providerManager types.ProviderManager) i.Tool
 		}()
 
 		// Create resource using provider manager
-		state, err := providerManager.CreateResource(ctx, args.GetProvider(), args.ResourceType, args.Config)
-		if err != nil {
-			err = fmt.Errorf("failed to create resource: %w", err)
+		state, createErr := providerManager.CreateResource(ctx, args.GetProvider(), args.ResourceType, args.Config)
+		if createErr != nil && len(state) == 0 {
+			err = fmt.Errorf("failed to create resource: %w", createErr)
 			return i.NewToolResultError(err.Error()), nil
 		}
 
-		// Handle empty state case
 		if len(state) == 0 {
 			return i.NewToolResultText("{}"), nil
 		}
@@ -136,6 +135,11 @@ func create(storage types.Storage, providerManager types.ProviderManager) i.Tool
 
 		if err = storage.SaveState(ctx, record); err != nil {
 			err = fmt.Errorf("failed to save state: %w", err)
+			return i.NewToolResultError(err.Error()), nil
+		}
+
+		if createErr != nil {
+			err = fmt.Errorf("failed to create resource: %w", createErr)
 			return i.NewToolResultError(err.Error()), nil
 		}
 


### PR DESCRIPTION
# Pull Request

## 📌 Reason

When `CreateResource` fails at the provider level — but the resource was actually provisioned in the cloud (e.g., the resource was created successfully, then a post-creation provisioner or validation step failed) — the partial state returned by the provider was silently discarded. The caller received `nil, error`, making it impossible to track the resource. In practice this leads to orphaned infrastructure: real cloud resources with no corresponding state record.

The Terraform provider protocol specifies that on a failed `ApplyResourceChange`, the response's `NewState` field should contain "the most recent known state of the resource, if it exists." We were ignoring this.

## 📄 Summary

Preserve partial resource state from the provider even when `ApplyManagedResourceChange` returns error diagnostics. The create tool handler now persists this state before returning the error, so that callers can track resources that were created despite an operation-level failure.

## 🔧 Changes Made

### Core Improvements
- OpenTofu adapter's `CreateResource` now extracts `PlannedNewState()` even when diagnostics report errors
- Create tool handler persists state before returning the error when partial state is available

### Technical Details
- `PlannedNewState()` can return nil when diagnostics have errors — explicit nil guard added
- State decoding failures on the error path fall back to returning nil + error (same behavior as before)
- Only the create path is changed — update, refresh, import, and delete are intentionally left unchanged

## 🎯 Technical Details

**Adapter (`provider/opentofu_adapter.go`)**: Previously, when `applyResp.Diagnostics().HasErrors()` was true, we returned `nil, error` immediately. Now the diagnostics error is captured but the state extraction path still runs. If state can be decoded, it is returned alongside the error. If `PlannedNewState()` is nil or cannot be decoded, we fall back to returning just the error.

The OpenTofu provider-client docs state that when diagnostics have errors, other response fields are "unspecified and meaningless." We handle this defensively at every step: nil check on `PlannedNewState()`, error handling on `AsCtyValue()`, error handling on `CtyValueToMap()`.

**Tool handler (`tools/lifecycle/resources/create.go`)**: The error check now distinguishes between "error with state" and "error without state." When state is present alongside an error, it is persisted before the error is returned. The deferred operation tracker still records the operation as failed.

The `ProviderManager.CreateResource` interface returns `(map[string]any, error)` — returning both a non-nil map and a non-nil error has always been valid. We are now using that capability for the first time.

**Why only create**: Update and refresh operate on resources with existing good state. On failure, the provider may return the prior state unchanged — persisting it would incorrectly change the resource's status. Import has additional policy evaluation steps that need separate consideration. Delete has different state removal semantics.

## ✅ Testing

- [x] Unit tests pass
- [x] No breaking changes to existing APIs — callers that check `err != nil` and ignore the map continue to work correctly
- [ ] Integration tests with a provider that returns partial state on error
- [ ] Manual testing completed

## 📋 Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] No sensitive information exposed
- [x] No breaking changes introduced
- [x] Error handling improved

## 🚀 Impact

Callers of `CreateResource` that previously received `nil, error` may now receive `stateMap, error` when the provider returns partial state alongside diagnostics errors. Callers that only check `err != nil` are unaffected. Callers that inspect the returned map on error can now use it to track resources created during failed operations.