### PR TITLE
chore: bump deprecated node20 GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
         run: go vet ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           args: --verbose
           version: v2.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,14 +33,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with: { platforms: linux/arm64 }
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           registry: ghcr.io
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         run: go tool cover -func=coverage.out
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage.out


### PR DESCRIPTION
Bumps GitHub Actions that were using the deprecated Node.js 20 runtime.

## Changes
- `actions/upload-artifact@v4 → actions/upload-artifact@v7`
- `docker/login-action@v3 → docker/login-action@v4`
- `docker/setup-buildx-action@v3 → docker/setup-buildx-action@v4`
- `docker/setup-qemu-action@v3 → docker/setup-qemu-action@v4`
- `golangci/golangci-lint-action@v8 → golangci/golangci-lint-action@v9`
- `goreleaser/goreleaser-action@v6 → goreleaser/goreleaser-action@v7`

## Why
Node.js 20 reached EOL in April 2026 and GitHub is deprecating it on Actions runners.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> ⚠️ Actions with potentially breaking changes (custom configs, major API changes) are excluded and need manual review.

🤖 Generated with Claude Code